### PR TITLE
Release/1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "heppokofrontend",
   "bugs": {
-    "url": "https://github.com/heppokofrontend/chrome-extension-hand-tool/issues"
+    "url": "https://github.com/heppokofrontend/chrome-extension-up-one-level/issues"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.220",
@@ -18,13 +18,13 @@
     "typescript": "^4.3.5",
     "uglify-js": "^3.17.4"
   },
-  "homepage": "https://github.com/heppokofrontend/chrome-extension-hand-tool#readme",
+  "homepage": "https://github.com/heppokofrontend/chrome-extension-up-one-level#readme",
   "keywords": [],
   "license": "MIT",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/heppokofrontend/chrome-extension-hand-tool.git"
+    "url": "git+https://github.com/heppokofrontend/chrome-extension-up-one-level.git"
   },
   "scripts": {
     "build": "tsc --build",

--- a/package/_locales/en/messages.json
+++ b/package/_locales/en/messages.json
@@ -8,10 +8,16 @@
   "shortcut": {
     "message": "Shortcut key: "
   },
-  "shortcut_false": {
+  "shortcut_enabled": {
+    "message": "Enabled (Alt+↑ / cmd+↑)"
+  },
+  "shortcut_disabled": {
     "message": "Disabled"
   },
-  "shortcut_true": {
-    "message": "Enabled (Alt+↑ / cmd+↑)"
+  "shortcut_to_enabled": {
+    "message": "Enabled"
+  },
+  "shortcut_to_disabled": {
+    "message": "Disabled"
   }
 }

--- a/package/_locales/ja/messages.json
+++ b/package/_locales/ja/messages.json
@@ -8,10 +8,16 @@
   "shortcut": {
     "message": "ショートカットキー："
   },
-  "shortcut_false": {
+  "shortcut_enabled": {
+    "message": "有効（Alt＋↑ / cmd＋↑）"
+  },
+  "shortcut_disabled": {
     "message": "無効"
   },
-  "shortcut_true": {
-    "message": "有効（Alt＋↑ / cmd＋↑）"
+  "shortcut_to_enabled": {
+    "message": "有効にする"
+  },
+  "shortcut_to_disabled": {
+    "message": "無効にする"
   }
 }

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "__MSG_extDesc__",
   "action": {
     "default_icon": "icon.png"

--- a/src/content-scripts.ts
+++ b/src/content-scripts.ts
@@ -43,14 +43,6 @@ const run = (tabId: number) => {
     return _url;
   })();
 
-  if (window.location.href === document.referrer) {
-    console.warn(
-      'Chrome Extension Up One Level: Current directory seems to be the root directory because the URL remains unchanged before transitioning.',
-    );
-
-    return;
-  }
-
   try {
     sessionStorage.setItem(storageKey, url);
   } catch {}

--- a/src/content-scripts.ts
+++ b/src/content-scripts.ts
@@ -52,6 +52,27 @@ const run = (tabId: number) => {
 
 let tabIdCache = -1;
 const onkeydownHandler = (e: KeyboardEvent) => {
+  const targetIsEditableElement = (target: EventTarget | null) => {
+    const { activeElement } = document;
+
+    if (activeElement === null || target !== activeElement) {
+      return false;
+    }
+
+    const isEditableElement =
+      activeElement instanceof HTMLElement &&
+      !['inherit', 'false'].includes(activeElement.contentEditable);
+    const isFormControls = ['input', 'textarea', 'select'].includes(
+      activeElement.tagName.toLowerCase(),
+    );
+
+    return isEditableElement || isFormControls;
+  };
+
+  if (targetIsEditableElement(e.target)) {
+    return;
+  }
+
   if (e.altKey || e.metaKey) {
     if (e.key === 'ArrowUp') {
       run(tabIdCache);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17,6 +17,7 @@
 
 {
   const contextMenuId = 'heppokofrontend-up-one-level';
+  const contextMenuIdForToggle = 'heppokofrontend-up-one-level-toggle';
   const sendEnabled = (tab: chrome.tabs.Tab | undefined, state: boolean, init?: boolean) => {
     if (tab) {
       if (tab.url?.startsWith('http') && typeof tab.id === 'number') {
@@ -27,10 +28,17 @@
     }
   };
 
-  chrome.contextMenus.create({
+  const parentId = chrome.contextMenus.create({
     id: contextMenuId,
-    title: `${chrome.i18n.getMessage('shortcut')}${chrome.i18n.getMessage('shortcut_false')}`,
+    title: `${chrome.i18n.getMessage('shortcut')}${chrome.i18n.getMessage('shortcut_disabled')}`,
     contexts: ['all'],
+  });
+
+  chrome.contextMenus.create({
+    id: contextMenuIdForToggle,
+    title: chrome.i18n.getMessage('shortcut_to_enabled'),
+    contexts: ['all'],
+    parentId,
   });
 
   chrome.storage.local.get('state', function (data) {
@@ -45,8 +53,12 @@
       if (tab.url?.startsWith('http') && typeof tab.id === 'number') {
         chrome.contextMenus.update(contextMenuId, {
           title: `${chrome.i18n.getMessage('shortcut')}${chrome.i18n.getMessage(
-            state ? 'shortcut_true' : 'shortcut_false',
+            state ? 'shortcut_enabled' : 'shortcut_disabled',
           )}`,
+          contexts: ['all'],
+        });
+        chrome.contextMenus.update(contextMenuIdForToggle, {
+          title: chrome.i18n.getMessage(state ? 'shortcut_to_disabled' : 'shortcut_to_enabled'),
           contexts: ['all'],
         });
 
@@ -64,8 +76,12 @@
       chrome.storage.local.set({ state });
       chrome.contextMenus.update(contextMenuId, {
         title: `${chrome.i18n.getMessage('shortcut')}${chrome.i18n.getMessage(
-          state ? 'shortcut_true' : 'shortcut_false',
+          state ? 'shortcut_enabled' : 'shortcut_disabled',
         )}`,
+        contexts: ['all'],
+      });
+      chrome.contextMenus.update(contextMenuIdForToggle, {
+        title: chrome.i18n.getMessage(state ? 'shortcut_to_disabled' : 'shortcut_to_enabled'),
         contexts: ['all'],
       });
 


### PR DESCRIPTION
- Removed the check that prevented operations when the previous URL and the current URL were the same to support SPA (Single Page Applications).
- Changed to disable shortcut keys when focusing on editable elements.
- Adjusted the context menu to toggle the enable/disable status of shortcut keys to prevent accidental presses.